### PR TITLE
Add DualNumber type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
 
-members = [
-    "interfaces", "tensors",
-]
+members = ["elements", "interfaces", "tensors"]
+
+resolver = "2"

--- a/elements/Cargo.toml
+++ b/elements/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+interfaces = { version = "0.1.0", path = "../interfaces" }

--- a/elements/Cargo.toml
+++ b/elements/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "elements"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/elements/Cargo.toml
+++ b/elements/Cargo.toml
@@ -4,4 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+float-cmp = "0.9.0"
 interfaces = { version = "0.1.0", path = "../interfaces" }

--- a/elements/src/dual_number.rs
+++ b/elements/src/dual_number.rs
@@ -1,0 +1,99 @@
+use std::{
+    fmt::Display,
+    ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign},
+};
+
+#[derive(Debug, Clone, Copy)]
+pub struct DualNumber {
+    pub real: f64,
+    pub dual: f64,
+}
+
+impl Display for DualNumber {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "({}, {})", self.real, self.dual)
+    }
+}
+
+impl DualNumber {
+    pub fn new(real: f64, dual: f64) -> Self {
+        Self { real, dual }
+    }
+}
+
+impl Add for DualNumber {
+    type Output = Self;
+    fn add(self, rhs: Self) -> Self {
+        Self::new(self.real + rhs.real, self.dual + rhs.dual)
+    }
+}
+
+impl AddAssign for DualNumber {
+    fn add_assign(&mut self, rhs: Self) {
+        self.real += rhs.real;
+        self.dual += rhs.dual;
+    }
+}
+
+impl Mul for DualNumber {
+    type Output = Self;
+    //  (ax + (ay + xb) i) =  (x + iy) * (a + bi)
+    fn mul(self, rhs: Self) -> Self::Output {
+        let real = self.real * rhs.real;
+        let dual = self.real * rhs.dual + self.dual * rhs.real;
+        Self::new(real, dual)
+    }
+}
+
+impl MulAssign for DualNumber {
+    fn mul_assign(&mut self, rhs: Self) {
+        self.real *= rhs.real;
+        self.dual = self.real * rhs.dual + self.dual * rhs.real;
+    }
+}
+
+impl Div for DualNumber {
+    type Output = Self;
+    //  (x + yi) / (a + bi)
+    //  = (x + yi)(a - bi) / ((a + bi)(a-bi))
+    //  = (ax + (ay - xb)i) / (a**2)
+    fn div(self, rhs: Self) -> Self::Output {
+        let denom = self.real * self.real;
+        let real = (self.real * rhs.real) / denom;
+        let dual = (self.real * rhs.dual - self.dual * rhs.real) / denom;
+        Self::new(real, dual)
+    }
+}
+
+impl DivAssign for DualNumber {
+    fn div_assign(&mut self, rhs: Self) {
+        let denom = self.real * self.real;
+        self.real = (self.real * rhs.real) / denom;
+        self.dual = (self.real * rhs.dual - self.dual * rhs.real) / denom;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_dual() {
+        let dual_a = DualNumber::new(3., 4.);
+        let dual_b = DualNumber::new(2., 3.);
+        let dual_mul = dual_a * dual_b;
+        assert_eq!(dual_mul.real, 6.);
+        assert_eq!(dual_mul.dual, 17.);
+    }
+
+    fn cube(dual_number: DualNumber) -> DualNumber {
+        dual_number * dual_number * dual_number
+    }
+
+    #[test]
+    fn test_cube() {
+        let dual_number = DualNumber::new(0.1, 1.);
+        let result = cube(dual_number);
+        println!("{}", result);
+    }
+}

--- a/elements/src/dual_number.rs
+++ b/elements/src/dual_number.rs
@@ -105,7 +105,20 @@ impl Pow for DualNumber {
 
 impl Element for DualNumber {}
 
-impl RealElement for DualNumber {}
+impl RealElement for DualNumber {
+    fn neg_inf() -> Self {
+        Self::new(-f64::INFINITY, 0.)
+    }
+    fn zero() -> Self {
+        Self::new(0., 0.)
+    }
+}
+
+impl From<f64> for DualNumber {
+    fn from(value: f64) -> Self {
+        Self::new(value, 0.)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/elements/src/dual_number.rs
+++ b/elements/src/dual_number.rs
@@ -59,9 +59,9 @@ impl MulAssign for DualNumber {
 
 impl Div for DualNumber {
     type Output = Self;
-    //  (x + yi) / (a + bi)
-    //  = (x + yi)(a - bi) / ((a + bi)(a-bi))
-    //  = (ax + (ay - xb)i) / (a**2)
+    //  (x + ye) / (a + be)
+    //  = (x + ye)(a - be) / ((a + be)(a - be))
+    //  = (ax + (ay - xb)e) / (a**2)
     fn div(self, rhs: Self) -> Self::Output {
         let denom = self.real * self.real;
         let real = (self.real * rhs.real) / denom;
@@ -109,7 +109,9 @@ impl RealElement for DualNumber {}
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
+    use float_cmp::assert_approx_eq;
 
     #[test]
     fn test_dual() {
@@ -128,6 +130,7 @@ mod tests {
     fn test_cube() {
         let dual_number = DualNumber::new(0.1, 1.);
         let result = cube(dual_number);
-        println!("{}", result);
+        assert_approx_eq!(f64, result.real, 0.001);
+        assert_approx_eq!(f64, result.dual, 0.03);
     }
 }

--- a/elements/src/lib.rs
+++ b/elements/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod dual_number;


### PR DESCRIPTION
Adds a type for working with [dual numbers](https://en.wikipedia.org/wiki/Dual_number) towards forward-mode autodiff.