### PR TITLE
1 autodiff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
 
-members = [
+members = [ "autodiff",
     "interfaces",
 ]

--- a/autodiff/Cargo.toml
+++ b/autodiff/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "autodiff"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/autodiff/Cargo.toml
+++ b/autodiff/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+interfaces = { path = "../interfaces"}

--- a/autodiff/src/lib.rs
+++ b/autodiff/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/autodiff/src/lib.rs
+++ b/autodiff/src/lib.rs
@@ -1,14 +1,16 @@
-pub fn add(left: usize, right: usize) -> usize {
-    left + right
-}
+pub mod node;
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+// pub fn add(left: usize, right: usize) -> usize {
+//     left + right
+// }
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+
+//     #[test]
+//     fn it_works() {
+//         let result = add(2, 2);
+//         assert_eq!(result, 4);
+//     }
+// }

--- a/autodiff/src/node.rs
+++ b/autodiff/src/node.rs
@@ -62,6 +62,17 @@ impl<T: RealElement> ops::Add<Node<T>> for Node<T> {
     }
 }
 
+impl<T: RealElement> ops::Mul<Node<T>> for Node<T> {
+    type Output = Node<T>;
+
+    fn mul(self, _rhs: Node<T>) -> Node<T> {
+        Node::Sum(
+            self.val().clone() * _rhs.val().clone(),
+            None,
+            (self.into(), _rhs.into()),
+        )
+    }
+}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -80,6 +91,16 @@ mod tests {
 
         let result = node1 + node2;
         assert_eq!(result.val(), &25.3_f64);
+        assert_eq!(result.grad(), None);
+    }
+
+    #[test]
+    fn test_mul() {
+        let node1 = Node::<f64>::new(3.1, Some(0.4));
+        let node2 = Node::<f64>::new(22.2, None);
+
+        let result = node1 * node2;
+        assert_eq!(result.val(), &68.82_f64);
         assert_eq!(result.grad(), None);
     }
 }

--- a/autodiff/src/node.rs
+++ b/autodiff/src/node.rs
@@ -1,14 +1,46 @@
+// /// A node in a computation graph.
+// pub struct Node<T> {
+//     val: T,          // value
+//     grad: Option<T>, // gradient
+//     dep: Vec<Node>,  // dependencies
+// }
+
+use std::rc::Rc;
+
 /// A node in a computation graph.
-pub struct Node<T> {
-    val: T,
-    grad: Option<T>,
+pub enum Node<T> {
+    Sum(T, Option<T>, (Rc<Node<T>>, Rc<Node<T>>)),
+    Prod(T, Option<T>, (Rc<Node<T>>, Rc<Node<T>>)),
+    Exp(T, Option<T>, Rc<Node<T>>),
+    Ln(T, Option<T>, Rc<Node<T>>),
+    Pow(T, Option<T>, (Rc<Node<T>>, Rc<Node<T>>)),
+    Leaf(T, Option<T>),
 }
 
 impl<T> Node<T> {
-    pub fn new(val: T) -> Self {
-        Node {
-            val: val,
-            grad: None,
+    pub fn new(val: T, grad: Option<T>) -> Self {
+        Node::Leaf(val, grad)
+    }
+
+    pub fn val(&self) -> &T {
+        match self {
+            Node::Sum(val, _, _)
+            | Node::Prod(val, _, _)
+            | Node::Exp(val, _, _)
+            | Node::Ln(val, _, _)
+            | Node::Pow(val, _, _)
+            | Node::Leaf(val, _) => val,
+        }
+    }
+
+    pub fn grad(&self) -> Option<&T> {
+        match self {
+            Node::Sum(_, grad, _)
+            | Node::Prod(_, grad, _)
+            | Node::Exp(_, grad, _)
+            | Node::Ln(_, grad, _)
+            | Node::Pow(_, grad, _)
+            | Node::Leaf(_, grad) => grad.as_ref(),
         }
     }
 }
@@ -19,8 +51,8 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let node = Node::<f64>::new(3.1);
-        assert_eq!(node.val, 3.1f64);
-        assert_eq!(node.grad, None);
+        let node = Node::<f64>::new(3.1, Some(0.4));
+        assert_eq!(node.val(), &3.1_f64);
+        assert_eq!(node.grad(), Some(&0.4));
     }
 }

--- a/autodiff/src/node.rs
+++ b/autodiff/src/node.rs
@@ -12,7 +12,7 @@ use std::{
 
 use interfaces::{
     tensors::RealElement,
-    utils::{Exp, Ln},
+    utils::{Exp, Ln, Pow},
 };
 
 /// A node in a computation graph.
@@ -102,7 +102,17 @@ impl<T: RealElement> Ln for Node<T> {
     }
 }
 
-// impl RealElement for Node<T> {}
+impl<T: RealElement> Pow for Node<T> {
+    fn pow(self, exp: Node<T>) -> Node<T> {
+        Node::Pow(
+            self.val().clone().pow(exp.val().clone()), // Note: unnecessary clone of exp.val() here?
+            None,
+            (self.into(), exp.into()),
+        )
+    }
+}
+
+// impl<T: RealElement> RealElement for Node<T> {}
 
 #[cfg(test)]
 mod tests {
@@ -152,5 +162,15 @@ mod tests {
 
         let result = node1 / node2;
         assert_eq!(result.val(), &f64::INFINITY);
+    }
+
+    #[test]
+    fn test_pow() {
+        let node1 = Node::<f64>::new(3.1, Some(0.4));
+        let node2 = Node::<f64>::new(22.2, None);
+
+        let result = node1.pow(node2);
+        assert_eq!(result.val(), &80952376567.60643_f64);
+        assert_eq!(result.grad(), None);
     }
 }

--- a/autodiff/src/node.rs
+++ b/autodiff/src/node.rs
@@ -6,16 +6,18 @@
 // }
 
 use std::{
+    fmt::Display,
     ops::{self, Add, AddAssign, Div, Mul},
     rc::Rc,
 };
 
 use interfaces::{
-    tensors::RealElement,
+    tensors::{Element, RealElement},
     utils::{Exp, Ln, Pow},
 };
 
 /// A node in a computation graph.
+#[derive(Debug, Clone)]
 pub enum Node<T> {
     Sum(T, Option<T>, (Rc<Node<T>>, Rc<Node<T>>)),
     Prod(T, Option<T>, (Rc<Node<T>>, Rc<Node<T>>)),
@@ -112,7 +114,20 @@ impl<T: RealElement> Pow for Node<T> {
     }
 }
 
-// impl<T: RealElement> RealElement for Node<T> {}
+impl<T: RealElement> AddAssign for Node<T> {
+    fn add_assign(&mut self, _rhs: Self) {
+        todo!()
+    }
+}
+
+impl<T: RealElement> Display for Node<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Node: {:?}", self)
+    }
+}
+
+impl<T: RealElement> Element for Node<T> {}
+impl<T: RealElement> RealElement for Node<T> {}
 
 #[cfg(test)]
 mod tests {
@@ -173,4 +188,10 @@ mod tests {
         assert_eq!(result.val(), &80952376567.60643_f64);
         assert_eq!(result.grad(), None);
     }
+
+    // #[test]
+    // fn test_fmt() {
+    //     let node = Node::<f64>::new(3.1, None);
+    //     println!("{}", node);
+    // }
 }

--- a/autodiff/src/node.rs
+++ b/autodiff/src/node.rs
@@ -66,12 +66,16 @@ impl<T: RealElement> ops::Mul<Node<T>> for Node<T> {
     type Output = Node<T>;
 
     fn mul(self, _rhs: Node<T>) -> Node<T> {
-        Node::Sum(
+        Node::Prod(
             self.val().clone() * _rhs.val().clone(),
             None,
             (self.into(), _rhs.into()),
         )
     }
+}
+
+impl RealElement for Node<T> {
+    
 }
 #[cfg(test)]
 mod tests {

--- a/autodiff/src/node.rs
+++ b/autodiff/src/node.rs
@@ -10,7 +10,10 @@ use std::{
     rc::Rc,
 };
 
-use interfaces::tensors::RealElement;
+use interfaces::{
+    tensors::RealElement,
+    utils::{Exp, Ln},
+};
 
 /// A node in a computation graph.
 pub enum Node<T> {
@@ -84,6 +87,18 @@ impl<T: RealElement> Div<Node<T>> for Node<T> {
             None,
             (self.into(), _rhs.into()),
         )
+    }
+}
+
+impl<T: RealElement> Exp for Node<T> {
+    fn exp(self) -> Self {
+        Node::Exp(self.val().clone().exp(), None, self.into())
+    }
+}
+
+impl<T: RealElement> Ln for Node<T> {
+    fn ln(self) -> Self {
+        Node::Exp(self.val().clone().ln(), None, self.into())
     }
 }
 

--- a/autodiff/src/node.rs
+++ b/autodiff/src/node.rs
@@ -78,6 +78,7 @@ impl<T: RealElement + From<f64>> Node<T> {
         let self_val = self.val().clone();
         let self_grad = <Option<T> as Clone>::clone(&self.grad()).unwrap();
 
+        // TODO: check all these: why is there a factor self_grad in Sum & Prod but not elsewhere?
         match self {
             Node::Sum(_, _, (ref mut n1, ref mut n2)) => {
                 n1.set_grad(self_grad.to_owned());
@@ -291,6 +292,7 @@ mod tests {
 
         let node = node1 + node2;
 
+        assert!(node.grad().is_none());
         match &node {
             Node::Sum(_, _, (n1, n2)) => {
                 assert!(n1.grad().is_none());
@@ -301,6 +303,8 @@ mod tests {
 
         let node = node.backward(5.0);
 
+        assert!(node.grad().is_some());
+        assert_eq!(node.grad().unwrap(), 5.0_f64);
         match &node {
             Node::Sum(_, _, (n1, n2)) => {
                 assert!(n1.grad().is_some());

--- a/autodiff/src/node.rs
+++ b/autodiff/src/node.rs
@@ -6,7 +6,7 @@
 // }
 
 use std::{
-    ops::{self, Add},
+    ops::{self, Add, AddAssign, Div, Mul},
     rc::Rc,
 };
 
@@ -50,7 +50,7 @@ impl<T: Add> Node<T> {
     }
 }
 
-impl<T: RealElement> ops::Add<Node<T>> for Node<T> {
+impl<T: RealElement> Add<Node<T>> for Node<T> {
     type Output = Node<T>;
 
     fn add(self, _rhs: Node<T>) -> Node<T> {
@@ -62,7 +62,7 @@ impl<T: RealElement> ops::Add<Node<T>> for Node<T> {
     }
 }
 
-impl<T: RealElement> ops::Mul<Node<T>> for Node<T> {
+impl<T: RealElement> Mul<Node<T>> for Node<T> {
     type Output = Node<T>;
 
     fn mul(self, _rhs: Node<T>) -> Node<T> {
@@ -74,9 +74,21 @@ impl<T: RealElement> ops::Mul<Node<T>> for Node<T> {
     }
 }
 
-impl RealElement for Node<T> {
-    
+impl<T: RealElement> Div<Node<T>> for Node<T> {
+    type Output = Node<T>;
+
+    fn div(self, _rhs: Node<T>) -> Node<T> {
+        // Same division by zero rules as standard division operator.
+        Node::Prod(
+            self.val().clone() / _rhs.val().clone(),
+            None,
+            (self.into(), _rhs.into()),
+        )
+    }
 }
+
+// impl RealElement for Node<T> {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -106,5 +118,24 @@ mod tests {
         let result = node1 * node2;
         assert_eq!(result.val(), &68.82_f64);
         assert_eq!(result.grad(), None);
+    }
+
+    #[test]
+    fn test_div() {
+        let node1 = Node::<f64>::new(3.1, Some(0.4));
+        let node2 = Node::<f64>::new(22.2, None);
+
+        let result = node1 / node2;
+        assert_eq!(result.val(), &0.13963963963963966_f64);
+        assert_eq!(result.grad(), None);
+    }
+
+    #[test]
+    fn test_div_by_zero() {
+        let node1 = Node::<f64>::new(3.1, Some(0.4));
+        let node2 = Node::<f64>::new(0.0, None);
+
+        let result = node1 / node2;
+        assert_eq!(result.val(), &f64::INFINITY);
     }
 }

--- a/autodiff/src/node.rs
+++ b/autodiff/src/node.rs
@@ -286,7 +286,7 @@ mod tests {
     // }
 
     #[test]
-    fn test_backward() {
+    fn test_backward_on_sum() {
         let node1 = Node::new(1.1, None);
         let node2 = Node::new(2.2, None);
 
@@ -311,6 +311,37 @@ mod tests {
                 assert_eq!(n1.grad().unwrap(), 5.0_f64);
                 assert!(n2.grad().is_some());
                 assert_eq!(n2.grad().unwrap(), 5.0_f64);
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn test_backward_on_prod() {
+        let node1 = Node::new(1.1, None);
+        let node2 = Node::new(2.2, None);
+
+        let node = node1 * node2;
+
+        assert!(node.grad().is_none());
+        match &node {
+            Node::Prod(_, _, (n1, n2)) => {
+                assert!(n1.grad().is_none());
+                assert!(n2.grad().is_none());
+            }
+            _ => panic!(),
+        }
+
+        let node = node.backward(5.0);
+
+        assert!(node.grad().is_some());
+        assert_eq!(node.grad().unwrap(), 5.0_f64);
+        match &node {
+            Node::Prod(_, _, (n1, n2)) => {
+                assert!(n1.grad().is_some());
+                assert_eq!(n1.grad().unwrap(), 11.0_f64);
+                assert!(n2.grad().is_some());
+                assert_eq!(n2.grad().unwrap(), 5.5_f64);
             }
             _ => panic!(),
         }

--- a/autodiff/src/node.rs
+++ b/autodiff/src/node.rs
@@ -1,0 +1,26 @@
+/// A node in a computation graph.
+pub struct Node<T> {
+    val: T,
+    grad: Option<T>,
+}
+
+impl<T> Node<T> {
+    pub fn new(val: T) -> Self {
+        Node {
+            val: val,
+            grad: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let node = Node::<f64>::new(3.1);
+        assert_eq!(node.val, 3.1f64);
+        assert_eq!(node.grad, None);
+    }
+}


### PR DESCRIPTION
Adds `Node<T>` implementation of `RealElement`, representing a node in a computation graph, with backward gradient propagation.